### PR TITLE
[Changed][DOC-1201] Updated CodeOwners file opensource project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-* @blv-dominik
+* @belvo-finance-opensource/documentation
+* @belvo-finance-opensource/experience
+* @belvo-finance-opensource/frontend


### PR DESCRIPTION
# What

In order to allow for Belvo-approved personnel to approve PRs we needed to update the codeowners files to include specific teams.